### PR TITLE
Fix example flake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Minimal configuration example using flakes and nix-darwin:
         nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
         darwin.url = "github:lnl7/nix-darwin/master";
         darwin.inputs.nixpkgs.follows = "nixpkgs";
-        nixpkgs-firefox-darwin = "github:bandithedoge/nixpkgs-firefox-darwin";
+        nixpkgs-firefox-darwin.url = "github:bandithedoge/nixpkgs-firefox-darwin";
     };
 
     outputs = { self, darwin, nixpkgs, ... }@inputs: {
         darwinConfigurations."machine" = darwin.lib.darwinSystem {
             system = "x86_64-darwin";
             modules = [
-                { nixpkgs.overlays = [ inputs.firefox-darwin.overlay ]; }
+                { nixpkgs.overlays = [ inputs.nixpkgs-firefox-darwin.overlay ]; }
                 ./configuration.nix
             ];
         };


### PR DESCRIPTION
This update fixes the example flake in the README.

## Problem
As shown in the current example, the flake fails to build with the message:
```
error: expected a set but got a string 
at /nix/store/qa2k73...89c3-source/flake.nix:11:5
```
Changing the line: 
```
nixpkgs-firefox-darwin = "github:bandithedoge/nixpkgs-firefox-darwin";
```
to
```
nixpkgs-firefox-darwin.url = "github:bandithedoge/nixpkgs-firefox-darwin";
```

fixes the error, but leads to a new error:

```
error: attribute 'firefox-darwin' missing
at /nix/store/s2xh...0hnn-source/flake.nix:61:29
```

Changing the line:
```
{ nixpkgs.overlays = [ inputs.firefox-darwin.overlay ]; }
```
to
```
{ nixpkgs.overlays = [ inputs.nixpkgs-firefox-darwin.overlay ]; }
```

resolves the issue and the flake builds successfully.