### PR TITLE
Workflows: Update actions & check packages upon push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: "Check evaluation"
+on: [push]
+jobs:
+  check_evaluation:
+    runs-on: macos-14 # The processor on this label is M1, not x86_64
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v25
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+
+      - name: Verify update.sh
+        run: |
+          chmod +x update.sh
+          ./update.sh
+
+      - name: Build nix packages
+        run: nix-build ci-shell.nix

--- a/.github/workflows/update-sources.yaml
+++ b/.github/workflows/update-sources.yaml
@@ -1,22 +1,23 @@
 ---
-name: update-sources
+name: "Update sources"
 on:
-  workflow_dispatch:
+  workflow_run:
+    workflows: ["Check evaluation"]
+    types:
+      - completed
   schedule:
     # runs every midnight
     - cron: "0 0 * * *"
-  push:
-    branches:
-      - main
+
 jobs:
   update-sources:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v16
+        uses: cachix/install-nix-action@v25
         with:
           nix_path: nixpkgs=channel:nixos-unstable
 
@@ -26,7 +27,7 @@ jobs:
           ./update.sh
 
       - name: Commit changes
-        uses: EndBug/add-and-commit@v7.5.0
+        uses: EndBug/add-and-commit@v9.1.4
         with:
           default_author: github_actions
           message: "Update sources"

--- a/ci-shell.nix
+++ b/ci-shell.nix
@@ -1,0 +1,10 @@
+{ pkgs ? import <nixpkgs> { overlays = [ (import ./overlay.nix) ]; } }:
+pkgs.mkShell {
+  packages = with pkgs; [
+    firefox-bin
+    firefox-beta-bin
+    firefox-devedition-bin
+    firefox-esr-bin
+    firefox-nightly-bin
+  ];
+}


### PR DESCRIPTION
### Description
Add support for creating a shell with overlays using `ci-shell.nix`. This allows us to test whether the overlay works as intended.

### Changes
- Added `ci-shell.nix` to the repository.
- Included `.github/workflows/build.yml` to execute `ci-shell.nix` upon push using a Github Actions’ M1-macOS 14 runner.
- Updated dependencies in `.github/workflows/build.yml` due to the deprecation of Node.js 16 actions in `checkout@v2`.
