### PR TITLE
Mention Floorp in README body

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nixpkgs-firefox-darwin
 
-The Nixpkgs repository has long struggled with broken `firefox` and `librewolf` packages on Darwin. Unfortunately, the `-bin` variants do not offer any support for Darwin. To address this issue, this overlay has been created, aiming to provide `-bin` packages for Firefox and Librewolf, generated directly from official builds.
+The Nixpkgs repository has long struggled with broken `firefox`, `librewolf`, and `floorp` packages on Darwin. Unfortunately, the `-bin` variants do not offer any support for Darwin. To address this issue, this overlay has been created, aiming to provide `-bin` packages for Firefox, Librewolf, and Floorp, generated directly from official builds.
 
 ## How to use it
 


### PR DESCRIPTION
It's in the code example already, but not mentioning it in the text seems like an omission.